### PR TITLE
return widget context.type

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,22 +3,18 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const App());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+class App extends StatelessWidget {
+  const App({Key? key}) : super(key: key);
 
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Places',
-      theme: ThemeData(
-        fontFamily: 'Roboto',
-        primarySwatch: Colors.blue,
-      ),
-      home: MyFirstStatefulWidget(),
+      title: 'xDDD',
+      home: MyFirstWidget(),
     );
   }
 }
@@ -26,6 +22,8 @@ class MyApp extends StatelessWidget {
 // ignore: prefer-single-widget-per-file
 class MyFirstWidget extends StatelessWidget {
   int _counter = 0;
+
+  //Type getContext() => context.runtimeType;
 
   MyFirstWidget({Key? key}) : super(key: key);
 
@@ -61,4 +59,6 @@ class _MyFirstStatefulWidgetState extends State<MyFirstStatefulWidget> {
       ),
     );
   }
+
+  Type getContext() => context.runtimeType;
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:places/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const App());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
- Переименуйте файл main.dart в start.dart. Запустите проект. Почему результат именно таков?
Ожидается, что точка входа в программу, функция main() находится в main.dart (по умолчанию). Но можно указать и другой файл с точкой входа.

- Задайте поле title. Запустите на Android. Где отобразится значение этого поля?
Сверху в списке недавних приложений

- Перейдем к рассмотрению контекста. В вашем Stateless виджет создайте метод без аргументов, который будет возвращать context.runtimeType. Получится ли реализовать подобное в данном виджете?
Не получится. Undefined name 'context'. StatelessWidget не предоставляет доступ к context вне метода build().

- Проделайте предыдущий пункт в рамках Stateful. В чем разница?
Доступ к context у StatefulWidget есть, так что информацию мы сможем получить.